### PR TITLE
#include fixes for windows

### DIFF
--- a/src/sansumbrella/box2d/Common.h
+++ b/src/sansumbrella/box2d/Common.h
@@ -32,6 +32,16 @@
 #include <Box2D/Box2D.h>
 #include <iostream>
 
+#include <functional>
+#include <vector>
+#include "cinder/Vector.h"
+#include "cinder/app/App.h"
+#include "cinder/gl/gl.h"
+
+ #ifdef WIN32
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif
+
 namespace box2d
 {
   typedef std::unique_ptr<b2Body, std::function<void(b2Body*)>>   unique_body_ptr;


### PR DESCRIPTION
Pretty function unfortunately doesn't exist in windows. Funcsig I
believe is the closest you can get. I'm not sure about the cinder
includes with respect to other platforms, but I needed them to compile
under windows.
