### PR TITLE
Batching for debug draw calls.

### DIFF
--- a/src/sansumbrella/box2d/Renderer.cpp
+++ b/src/sansumbrella/box2d/Renderer.cpp
@@ -27,6 +27,9 @@
 
 #include "Renderer.h"
 #include "cinder/gl/gl.h"
+#include "cinder/gl/Context.h"
+#include "cinder/gl/Vao.h"
+#include "cinder/gl/Vbo.h"
 
 using namespace box2d;
 using namespace cinder;
@@ -49,78 +52,180 @@ void Renderer::updateFlags()
            (drawCenterOfMass * e_centerOfMassBit ) );
 }
 
+void Renderer::flush()
+{
+  auto &context = *gl::context();
+  const auto &shader = context.getGlslProg();
+  const auto &vao = context.getDefaultVao();
+  const auto &vbo = context.getDefaultArrayVbo(sizeof(Vertex) * glm::max(_triangle_vertices.size(), _line_vertices.size()));
+
+  gl::ScopedVao         vao_scope(vao);
+  gl::ScopedBuffer      vbo_scope(vbo);
+  gl::ScopedAlphaBlend  blend(true);
+
+  vao->replacementBindBegin();
+  auto position_loc = shader->getAttribSemanticLocation(geom::POSITION);
+  auto color_loc = shader->getAttribSemanticLocation(geom::COLOR);
+  gl::enableVertexAttribArray(position_loc);
+  gl::vertexAttribPointer(position_loc, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (GLvoid*)offsetof(Vertex, position));
+  gl::enableVertexAttribArray(color_loc);
+  gl::vertexAttribPointer(color_loc, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (GLvoid*)offsetof(Vertex, color));
+  vao->replacementBindEnd();
+  context.setDefaultShaderVars();
+
+  {
+    // Draw Polygons
+    vbo->bufferSubData(0, sizeof(Vertex) * _triangle_vertices.size(), _triangle_vertices.data());
+
+    context.drawArrays(GL_TRIANGLES, 0, _triangle_vertices.size());
+  }
+
+  {
+    // Draw Lines
+    vbo->bufferSubData(0, sizeof(Vertex) * _line_vertices.size(), _line_vertices.data());
+
+    context.drawArrays(GL_LINES, 0, _line_vertices.size());
+  }
+
+  _line_vertices.clear();
+  _triangle_vertices.clear();
+}
+
 void Renderer::DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)
 {
-  Path2d path;
-  path.moveTo( vertices[0].x, vertices[0].y );
-  for( int i = 1; i < vertexCount; ++i )
+  ColorA c = ColorA(color.r, color.g, color.b);
+  vec2 p1 = vec2(vertices[vertexCount - 1].x, vertices[vertexCount - 1].y);
+  for (int i = 0; i < vertexCount; ++i)
   {
-    path.lineTo( vertices[i].x, vertices[i].y );
+    vec2 p2 = vec2(vertices[i].x, vertices[i].y);
+    _line_vertices.push_back(Vertex{p1, c});
+    _line_vertices.push_back(Vertex{p2, c});
+    p1 = p2;
   }
-  path.close();
-
-  gl::ScopedColor c( Color( color.r, color.g, color.b ) );
-  gl::draw( path );
 }
 
 void Renderer::DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)
 {
-  Path2d path;
-  path.moveTo( vertices[0].x, vertices[0].y );
-  for( int i = 1; i < vertexCount; ++i )
+  ColorA c = ColorA(color.r, color.g, color.b) * 0.5f;
+
+  vec2 p0 = vec2(vertices[0].x, vertices[0].y);
+
+  for (int i = 1; i < vertexCount - 1; ++i)
   {
-    path.lineTo( vertices[i].x, vertices[i].y );
+    auto pi = vec2(vertices[i].x, vertices[i].y);
+    auto pi1 = vec2(vertices[i + 1].x, vertices[i + 1].y);
+    _triangle_vertices.push_back(Vertex{p0, c});
+    _triangle_vertices.push_back(Vertex{pi, c});
+    _triangle_vertices.push_back(Vertex{pi1, c});
   }
-  path.close();
 
-  gl::ScopedAlphaBlend blend( false );
-  gl::ScopedColor c( ColorA( color.r, color.g, color.b, 0.5f ) );
-  gl::drawSolid( path );
-  gl::draw( path );
+  DrawPolygon(vertices, vertexCount, color);
 }
 
-void Renderer::DrawCircle(const b2Vec2& center, float32 radius, const b2Color& color)
+void Renderer::DrawCircle(const b2Vec2& b2_center, float32 radius, const b2Color& b2_color)
 {
-  gl::color( color.r, color.g, color.b );
-  gl::drawStrokedCircle( vec2{center.x, center.y}, radius );
+  const float segments = 16;
+  const float increment = 2.0f * M_PI / segments;
+
+  const float sin_inc = sin(increment);
+  const float cos_inc = cos(increment);
+
+  ColorA color(b2_color.r, b2_color.g, b2_color.b);
+  vec2 center = vec2(b2_center.x, b2_center.y);
+  vec2 r1(1, 0);
+  vec2 v1 = center + r1 * radius;
+  for (int i = 0; i < segments; ++i)
+  {
+    vec2 r2 = vec2(cos_inc * r1.x - sin_inc * r1.y, sin_inc * r1.x + cos_inc * r1.y);
+    vec2 v2 = center + r2 * radius;
+
+    _line_vertices.push_back(Vertex{v1, color});
+    _line_vertices.push_back(Vertex{v2, color});
+
+    r1 = r2;
+    v1 = v2;
+  }
 }
 
-void Renderer::DrawSolidCircle(const b2Vec2& center, float32 radius, const b2Vec2& axis, const b2Color& color)
+void Renderer::DrawSolidCircle(const b2Vec2& b2_center, float32 radius, const b2Vec2& b2_axis, const b2Color& b2_color)
 {
-  gl::enableAlphaBlending();
-  gl::ScopedColor c( ColorA( color.r, color.g, color.b, 0.5f ) );
-  gl::drawSolidCircle( vec2{ center.x, center.y }, radius, 16 );
-  gl::disableAlphaBlending();
-  gl::drawStrokedCircle( vec2{center.x, center.y}, radius, 16 );
+  const float segments = 16;
+  const float increment = 2.0f * M_PI / segments;
+
+  const float sin_inc = sin(increment);
+  const float cos_inc = cos(increment);
+
+  const auto color = ColorA(b2_color.r, b2_color.g, b2_color.b) * 0.5f;
+  const vec2 center = vec2(b2_center.x, b2_center.y);
+  vec2 r1(1, 0);
+  vec2 v1 = center + r1 * radius;
+
+  // Triangles
+  for (int i = 0; i < segments; ++i)
+  {
+    // r2 is a rotation of r1
+    vec2 r2 = vec2(cos_inc * r1.x - sin_inc * r1.y, sin_inc * r1.x + cos_inc * r1.y);
+    vec2 v2 = center + r2 * radius;
+
+    _triangle_vertices.push_back(Vertex{center, color});
+    _triangle_vertices.push_back(Vertex{v1, color});
+    _triangle_vertices.push_back(Vertex{v2, color});
+
+    r1 = r2;
+    v1 = v2;
+  }
+
+  // Lines
+  r1 = vec2(1, 0);
+  v1 = center + r1 * radius;
+  for (int i = 0; i < segments; ++i)
+  {
+    // r2 is a rotation of r1
+    vec2 r2 = vec2(cos_inc * r1.x - sin_inc * r1.y, sin_inc * r1.x + cos_inc * r1.y);
+    vec2 v2 = center + r2 * radius;
+
+    _line_vertices.push_back(Vertex{v1, color});
+    _line_vertices.push_back(Vertex{v2, color});
+
+    r1 = r2;
+    v1 = v2;
+  }
 }
 
 void Renderer::DrawSegment(const b2Vec2& p1, const b2Vec2& p2, const b2Color& color)
 {
-  gl::color(color.r, color.g, color.b);
-  gl::drawLine( vec2{ p1.x, p1.y }, vec2{ p2.x, p2.y } );
+  ColorA c(color.r, color.g, color.b);
+  _line_vertices.push_back(Vertex{vec2(p1.x, p1.y), c});
+  _line_vertices.push_back(Vertex{vec2(p2.x, p2.y), c});
 }
 
-void Renderer::DrawTransform(const b2Transform& xf)
+void Renderer::DrawTransform(const b2Transform& transform)
 {
-	b2Vec2 p1 = xf.p, p2;
-	const float32 k_axisScale = 0.4f;
+  const float32 scaling = 0.4f;
+  auto x = transform.q.GetXAxis();
+  auto y = transform.q.GetYAxis();
+  vec2 center = vec2(transform.p.x, transform.p.y);
+  vec2 right = center + vec2(x.x, x.y) * scaling;
+  vec2 up = center + vec2(y.x, y.y) * scaling;
 
-  gl::ScopedColor red( Color( 1, 0, 0 ) );
-	gl::color(1.0f, 0.0f, 0.0f);
-	p2 = p1 + k_axisScale * xf.q.GetXAxis();
-	gl::drawLine( vec2{ p1.x, p1.y }, vec2{ p2.x, p2.y } );
+  ColorA red(1, 0, 0);
+  ColorA green(0, 1, 0);
 
-	gl::ScopedColor green( Color( 0, 1, 0 ) );
-	p2 = p1 + k_axisScale * xf.q.GetYAxis();
-	gl::drawLine( vec2{ p1.x, p1.y }, vec2{ p2.x, p2.y } );
+  _line_vertices.push_back(Vertex{center, red});
+  _line_vertices.push_back(Vertex{right, red});
+
+  _line_vertices.push_back(Vertex{center, green});
+  _line_vertices.push_back(Vertex{up, green});
 }
 
 void Renderer::DrawPoint(const b2Vec2& p, float32 size, const b2Color& color)
 {
-  gl::ScopedColor c( Color( color.r, color.g, color.b ) );
-  gl::lineWidth( size );
-	gl::drawSolidCircle( vec2( p.x, p.y ), size * 0.5f );
-  gl::lineWidth( 1.0f );
+  vec2 pos = vec2(p.x, p.y);
+
+  ColorA c(color.r, color.g, color.b);
+
+  _line_vertices.push_back(Vertex{pos, c});
+  _line_vertices.push_back(Vertex{pos, c});
 }
 
 void Renderer::DrawString(int x, int y, const char* string, ...)
@@ -131,6 +236,18 @@ void Renderer::DrawString(int x, int y, const char* string, ...)
 
 void Renderer::DrawAABB(b2AABB* aabb, const b2Color& color)
 {
-  gl::ScopedColor c( Color( color.r, color.g, color.b ) );
-  gl::drawStrokedRect( Rectf{ aabb->upperBound.x, aabb->upperBound.y, aabb->lowerBound.x, aabb->lowerBound.y }  );
+  const Rectf outline( aabb->upperBound.x, aabb->upperBound.y, aabb->lowerBound.x, aabb->lowerBound.y );
+  const ColorA c( color.r, color.g, color.b );
+
+  _line_vertices.push_back(Vertex{outline.getUpperRight(), c});
+  _line_vertices.push_back(Vertex{outline.getUpperLeft(), c});
+
+  _line_vertices.push_back(Vertex{outline.getUpperLeft(), c});
+  _line_vertices.push_back(Vertex{outline.getLowerLeft(), c});
+
+  _line_vertices.push_back(Vertex{outline.getLowerLeft(), c});
+  _line_vertices.push_back(Vertex{outline.getLowerRight(), c});
+
+  _line_vertices.push_back(Vertex{outline.getLowerRight(), c});
+  _line_vertices.push_back(Vertex{outline.getUpperRight(), c});
 }

--- a/src/sansumbrella/box2d/Renderer.h
+++ b/src/sansumbrella/box2d/Renderer.h
@@ -46,6 +46,7 @@ namespace box2d
     void DrawString(int x, int y, const char* string, ...);
     void DrawAABB(b2AABB* aabb, const b2Color& color);
 
+    void flush();
 /*
     void drawShapes( bool doDraw ) { drawShape = doDraw; updateFlags(); }
     void drawJoints( bool doDraw ) { drawJoint = doDraw; updateFlags(); }
@@ -60,5 +61,14 @@ namespace box2d
     int drawPair = 0;
     int drawCenterOfMass = 1;
     void updateFlags();
+
+    struct Vertex
+    {
+      ci::vec2    position;
+      ci::ColorA  color;
+    };
+
+    std::vector<Vertex> _triangle_vertices;
+    std::vector<Vertex> _line_vertices;
   };
 }

--- a/src/sansumbrella/box2d/Sandbox.cpp
+++ b/src/sansumbrella/box2d/Sandbox.cpp
@@ -62,6 +62,7 @@ void Sandbox::debugDraw( float points_per_meter )
 	gl::pushModelMatrix();
 	gl::scale( points_per_meter, points_per_meter );
   mWorld.DrawDebugData();
+  mDebugRenderer.flush();
   gl::popModelMatrix();
 }
 


### PR DESCRIPTION
Don't issue gl calls immediately, but cache as triangles and lines.
Getting a huge performance improvement in an iOS test scene:

Before: ~20ms CPU time per draw loop
Now:    ~ 3ms CPU time per draw loop

Now the debug renderer is useful for iOS projects. Phew!